### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,28 +1,28 @@
 {
-    "name": "Create JSON with reference items",
-    "type": "app",
-    "categories": [
-        "images",
-        "export"
-    ],
-    "description": "Objects with specific tag will be treated as reference items",
-    "docker_image": "supervisely/import-export:6.73.564",
-    "instance_version": "6.15.60",
-    "main_script": "src/main.py",
-    "modal_template": "src/modal.html",
-    "modal_template_state": {
-        "tag": "",
-        "keyImageField": ""
-    },
-    "task_location": "workspace_tasks",
-    "icon": "https://img.icons8.com/color/96/000000/product-documents.png",
-    "icon_background": "#FFFFFF",
-    "headless": true,
-    "disable_stop": true,
-    "context_menu": {
-        "target": [
-            "images_project"
-        ]
-    },
-    "poster": "https://user-images.githubusercontent.com/106374579/182887484-5f79272a-99e5-4bc2-b2e3-a2c9595d1ccc.png"
+  "name": "Create JSON with reference items",
+  "type": "app",
+  "categories": [
+    "images",
+    "export"
+  ],
+  "description": "Objects with specific tag will be treated as reference items",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/main.py",
+  "modal_template": "src/modal.html",
+  "modal_template_state": {
+    "tag": "",
+    "keyImageField": ""
+  },
+  "task_location": "workspace_tasks",
+  "icon": "https://img.icons8.com/color/96/000000/product-documents.png",
+  "icon_background": "#FFFFFF",
+  "headless": true,
+  "disable_stop": true,
+  "context_menu": {
+    "target": [
+      "images_project"
+    ]
+  },
+  "poster": "https://user-images.githubusercontent.com/106374579/182887484-5f79272a-99e5-4bc2-b2e3-a2c9595d1ccc.png"
 }

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "export"
   ],
   "description": "Objects with specific tag will be treated as reference items",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     ],
     "description": "Objects with specific tag will be treated as reference items",
     "docker_image": "supervisely/import-export:6.73.564",
-    "min_instance_version": "6.8.48",
+    "instance_version": "6.15.60",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",
     "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
         "export"
     ],
     "description": "Objects with specific tag will be treated as reference items",
-    "docker_image": "supervisely/import-export:6.72.216",
+    "docker_image": "supervisely/import-export:6.73.564",
     "min_instance_version": "6.8.48",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.216
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
